### PR TITLE
Bug/co 1176 contact name

### DIFF
--- a/src/main/groovy/edu/oregonstate/mist/osuevents/db/EventsDAO.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/osuevents/db/EventsDAO.groovy
@@ -44,8 +44,9 @@ public interface EventsDAO extends Closeable {
             OWNER
         FROM EVENTS_EVENTS
         WHERE (EVENT_ID = :eventID OR :eventID IS NULL)
-	 AND (CREATED_AT >= SYSDATE - :changedInPastHours/24 OR :changedInPastHours IS NULL)
-	 AND (UPDATED_AT >= SYSDATE - :changedInPastHours/24 OR :changedInPastHours IS NULL)
+        AND (CREATED_AT >= SYSDATE - :changedInPastHours/24
+            OR UPDATED_AT >= SYSDATE - :changedInPastHours/24
+            OR :changedInPastHours IS NULL)
         AND DELETED_AT IS NULL
     """)
     @Mapper(EventMapper)

--- a/src/main/groovy/edu/oregonstate/mist/osuevents/resources/FeedResource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/osuevents/resources/FeedResource.groovy
@@ -335,7 +335,7 @@ class FeedEvent {
         bool ? "1" : null
     }
 
-    @JsonProperty("Contact name for event questions or disability accommodations")
+    @JsonProperty("Contact Name")
     String contactName
     @JsonProperty("Contact Email")
     String contactEmail


### PR DESCRIPTION
This fixes two bugs:

1. FeedResource: the field name expected in the csv name for Contact name differed between staging and prod, so this change favors the prod field name.

2. EventsDao: If changedInPastHours was non-null, it would only bring back events where created_at AND updated_at were from the past whatever hours. This should be an or.