### PR TITLE
Bug/co 1240 visibility field

### DIFF
--- a/src/main/groovy/edu/oregonstate/mist/osuevents/core/Event.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/osuevents/core/Event.groovy
@@ -65,12 +65,30 @@ class Event {
      */
     public static Event fromResultObject(ResultObject resultObject) {
         try {
-            objectMapper.convertValue(resultObject.data['attributes'], Event.class)
+            Event event = objectMapper.convertValue(resultObject.data['attributes'], Event.class)
+            event.with {
+                locationID = trimID(locationID)
+                countyIDs = trimID(countyIDs)
+                campusID = trimID(campusID)
+                departmentIDs = trimID(departmentIDs)
+                eventTypeIDs = trimID(eventTypeIDs)
+                eventTopicIDs = trimID(eventTopicIDs)
+                audienceIDs = trimID(audienceIDs)
+            }
+            event
         } catch (IllegalArgumentException e) {
             throw new EventException("Some fields weren't able to map to an event object.")
         } catch (NullPointerException e) {
             throw new EventException("Could not parse result object.")
         }
+    }
+
+    private static trimID(List<String> IDs) {
+        IDs ? IDs.collect { it.trim() }.unique() : IDs
+    }
+
+    private static trimID(String ID) {
+        ID ? ID.trim() : ID
     }
 
     public static List<String> validVisibilityValues = [

--- a/src/main/groovy/edu/oregonstate/mist/osuevents/core/Event.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/osuevents/core/Event.groovy
@@ -75,9 +75,7 @@ class Event {
 
     public static List<String> validVisibilityValues = [
             "Unlisted",
-            "Place Pages",
-            "Widgets",
-            "Logged-In Users Only",
+            "Restricted",
             "Channels"
     ]
 

--- a/src/main/groovy/edu/oregonstate/mist/osuevents/core/Event.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/osuevents/core/Event.groovy
@@ -91,10 +91,14 @@ class Event {
         ID ? ID.trim() : ID
     }
 
+    public static final String unlistedVisibility = "Unlisted"
+    public static final String restrictedVisibility = "Restricted"
+    public static final String channelsVisibility = "Channels"
+
     public static List<String> validVisibilityValues = [
-            "Unlisted",
-            "Restricted",
-            "Channels"
+            unlistedVisibility,
+            restrictedVisibility,
+            channelsVisibility
     ]
 
     @JsonIgnore

--- a/src/main/groovy/edu/oregonstate/mist/osuevents/resources/FeedResource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/osuevents/resources/FeedResource.groovy
@@ -173,6 +173,8 @@ class FeedResource extends Resource {
                             campuses[event.campusID] = feedEvent.campus = campusName
                         }
                     }
+
+                    setChannelsOnly(event.visibility == "Channels")
                 }
                 feedEvents.add(feedEvent)
             }
@@ -373,4 +375,11 @@ class FeedEvent {
 
     @JsonProperty("Visibility")
     String visibility
+
+    @JsonProperty("Channels Only")
+    String channelsOnly
+    @JsonIgnore
+    void setChannelsOnly(Boolean channelsOnly) {
+        this.channelsOnly = parseBoolean(channelsOnly)
+    }
 }

--- a/src/main/groovy/edu/oregonstate/mist/osuevents/resources/FeedResource.groovy
+++ b/src/main/groovy/edu/oregonstate/mist/osuevents/resources/FeedResource.groovy
@@ -94,8 +94,7 @@ class FeedResource extends Resource {
                         hashtag: event.hashtag,
                         contactName: event.contactName,
                         contactEmail: event.contactEmail,
-                        contactPhone: event.contactPhone,
-                        visibility: event.visibility
+                        contactPhone: event.contactPhone
                 )
 
                 feedEvent.with {
@@ -174,7 +173,12 @@ class FeedResource extends Resource {
                         }
                     }
 
-                    setChannelsOnly(event.visibility == "Channels")
+                    if (event.visibility == Event.channelsVisibility) {
+                        setChannelsOnly(true)
+                        visibility = Event.restrictedVisibility
+                    } else {
+                        visibility = event.visibility
+                    }
                 }
                 feedEvents.add(feedEvent)
             }


### PR DESCRIPTION
Changes:

- Add the 'Channels Only' field to the feed resource. If the visibility of the event object is 'Channels', then Channels Only is set to `true` in the feed as well as the visibility is changed to 'Restricted'. Keeping the Channels value as a valid visibility maintains backward compatibility, so this is not a breaking change. Only the 'Channels' was ever being used for that field, so removing the other values doesn't break any integrations.

- ID fields could've been valid if they contained a space around them, so I trimmed all ID fields.

- ID list fields also could contain duplicates, which is unnecessary, so I made the API save only the unique (and trimmed) values.